### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,5 @@ install:
     - cpanm -v --installdeps --notest .
 
 script:
-    - cd File-Dir-Dumper
     - perl Build.PL
     - ./Build test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: "perl"
+perl:
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+
+before_install:
+    # optional dependencies
+    - cpanm Test::CPAN::Changes Test::Pod::Coverage Test::TrailingSpace
+
+install:
+    - cpanm -v --installdeps --notest .
+
+script:
+    - cd File-Dir-Dumper
+    - perl Build.PL
+    - ./Build test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
     - cpanm Test::CPAN::Changes Test::Pod::Coverage Test::TrailingSpace
 
 install:
+    - cd File-Dir-Dumper
     - cpanm -v --installdeps --notest .
 
 script:


### PR DESCRIPTION
This Travis CI config tests on Perl versions between 5.12 and 5.24 and installs optional dependencies so all tests run.

You will need to enable Travis CI on your repository _first_, then merge this PR. That way travis will run your tests when you merge. Otherwise it won't run until the next commit.

Fixes #2
